### PR TITLE
Change file content regex matching logic to check entire wordlist

### DIFF
--- a/pysnaffler/rules/contents.py
+++ b/pysnaffler/rules/contents.py
@@ -8,16 +8,12 @@ class SnafflerContentsEnumerationRule(SnaffleRule):
 		super().__init__(enumerationScope, ruleName, matchAction, relayTargets, description, matchLocation, wordListType, matchLength, wordList, triage)
 	
 	def match(self, data):
+		matches = []
 		for rex in self.wordList:
 			res = rex.findall(data)
-			if res is not None:
-				for r in res:
-					if r != '':
-						break
-				else:
-					return ''
-				return '\r\n'.join(res)
-		return None
+			if res != None and res != []:
+				matches += res
+		return '\r\n'.join(matches)
 
 	def open_and_match(self, filename):
 		try:


### PR DESCRIPTION
The current match function returns an empty string if the first word on the wordlist doesn't match. If a regex doesn't match, res is an empty array. Therefore the else branch of the for loop is taken and an empty string is returned.
The new function always checks all words from the wordlist, stores the matches in an array and returns a string containing all matches.