### PR TITLE
Show result when a rule directly snaffles a file without relays

### DIFF
--- a/pysnaffler/ruleset.py
+++ b/pysnaffler/ruleset.py
@@ -188,6 +188,10 @@ class SnafflerRuleSet:
 		for rule in finalrules:
 			if rule.enumerationScope == EnumerationScope.ContentsEnumeration:
 				res, err = rule.open_and_match(filepath)
+				if err is not None:
+					yield None, rule, err
+				if res:
+					yield res, rule, None
 			else:
 				temp = SMBFile.from_uncpath(filepath)
 				temp.size = fsize
@@ -198,9 +202,6 @@ class SnafflerRuleSet:
 				# TODO: check if we need to be recursive here
 				err = None
 				res = ''
-			if err is not None:
-				yield None, rule, err
-			if res:
 				yield res, rule, None
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some Snaffler rules directly snaffle a file based on the name without relaying it to other rules, e.g. the rule KeepPasswordFilesByName snaffles files named passwords.txt. In this case the enumerationScope is not ContentsEnumeration and the else branch is taken where res is set to the empty string. At the end nothing is yielded because res is casted to False.
The new parse_file function always yields a result when a match is found during FileEnumeration.