### PR TITLE
Add slashes to directory to be compatible with original snaffler rules

### DIFF
--- a/pysnaffler/ruleset.py
+++ b/pysnaffler/ruleset.py
@@ -31,6 +31,8 @@ class SnafflerRuleSet:
 
 	def enum_directory(self, directory) -> Tuple[bool, List[Triage]]:
 		rules = []
+		if directory.startswith('\\') is False:
+			directory = '\\' + directory
 		for rule in self.directoryEnumerationRules.values():
 			action, triage = rule.determine_action(directory)
 			if action is MatchAction.Discard:


### PR DESCRIPTION
Some of the Snaffler rules expect the directory to start with \\, e.g. the DiscardWinSystemDirs rule will discard the directory \\system32. When ADMIN$ is enumerated, the directory name that is returned during enumeration is just system32. This patch adds \\ to every path. Since all Snaffler rules for directories use the contains operator, this should not cause any directory that has matched previously to not match after this change.