### PR TITLE
Remove empty subdirectories after scan finishes

### DIFF
--- a/pysnaffler/__main__.py
+++ b/pysnaffler/__main__.py
@@ -64,6 +64,7 @@ async def amain():
 	tgen = UniTargetGen.from_list(args.targets)
 	scanner = UniScanner('Snaffler', executors, [tgen], worker_count=args.worker_count, host_timeout=timeout)
 	await scanner.scan_and_process(progress=args.no_progress, out_file=args.out_file, include_errors=args.errors)
+	snaffler.clean_working_directory()
 	snaffler.print_stats()
 
 

--- a/pysnaffler/snaffler.py
+++ b/pysnaffler/snaffler.py
@@ -3,6 +3,7 @@ from pysnaffler.ruleset import SnafflerRuleSet
 from pysnaffler.utils import sizeof_fmt
 from typing import List
 import toml
+import os
 
 class pySnaffler:
 	def __init__(self, ruleset:SnafflerRuleSet = None, max_file_size:int = 10485760, max_connections:int = 200, 
@@ -45,6 +46,13 @@ class pySnaffler:
 	def to_toml(self):
 		# serialize all the settings to a toml file
 		return toml.dumps(self.to_dict())
+
+	def clean_working_directory(self):
+		for directory, subdirs, _ in os.walk(self.download_base_dir, topdown=False):
+			for subdir in subdirs:
+				path = os.path.join(directory, subdir)
+				if len(os.listdir(path)) == 0:
+					os.rmdir(path)
 
 	@staticmethod
 	def from_dict(d:dict):


### PR DESCRIPTION
This code will automatically delete all empty subdirectories after a scan. This leaves only the directories that contain a file that has matched a rule.