### PR TITLE
Add options to include characters before and after a match in the output file

### DIFF
--- a/pysnaffler/__main__.py
+++ b/pysnaffler/__main__.py
@@ -26,6 +26,8 @@ async def amain():
 	parser.add_argument('-l', '--filelist', action='store_true', help='Generates filelist file containing a list of files and folders enumerated')
 	parser.add_argument('-k', '--keep-files', action='store_true', help='Keeps downloaded files on disk after parsing')
 	parser.add_argument('-b', '--base-path', default = 'snaffler_downloads', help='Base directory path for downloaded files')
+	parser.add_argument('--chars-before-match', type=int, default=0, help='Number of characters to show in output file before a match')
+	parser.add_argument('--chars-after-match', type=int, default=0, help='Number of characters to show in output file after a match')
 	parser.add_argument('-c', '--config', help='Path to config file. Overrides all other options.')
 	parser.add_argument('url', help = 'Connection string in URL format')
 	parser.add_argument('targets', nargs='*', help = 'Hostname or IP address or file with a list of targets')
@@ -55,7 +57,9 @@ async def amain():
 			args.keep_files,
 			args.base_path,
 			args.dry_run,
-			args.filelist
+			args.filelist,
+			args.chars_before_match,
+			args.chars_after_match
 		)
 	
 	#print('Running config:')

--- a/pysnaffler/rules/contents.py
+++ b/pysnaffler/rules/contents.py
@@ -7,24 +7,28 @@ class SnafflerContentsEnumerationRule(SnaffleRule):
 	def __init__(self, enumerationScope:EnumerationScope, ruleName:str, matchAction:MatchAction, relayTargets:List[str], description:str, matchLocation:MatchLoc, wordListType:MatchListType, matchLength:int, wordList:List[str], triage:Triage):
 		super().__init__(enumerationScope, ruleName, matchAction, relayTargets, description, matchLocation, wordListType, matchLength, wordList, triage)
 	
-	def match(self, data):
+	def match(self, data, chars_before = 0, chars_after = 0):
 		matches = []
 		for rex in self.wordList:
-			res = rex.findall(data)
-			if res != None and res != []:
-				matches += res
+			for match in rex.finditer(data):
+				text = match.group(0)
+				if chars_before > 0:
+					text = data[max(match.start() - chars_before, 0) : match.start()] + text
+				if chars_after > 0:
+					text += data[match.end() : min(match.end() + chars_after, len(data))]
+				matches.append(text)
 		return '\r\n'.join(matches)
 
-	def open_and_match(self, filename):
+	def open_and_match(self, filename, chars_before, chars_after):
 		try:
 			if self.matchLocation == MatchLoc.FileContentAsString:
 				with codecs.open(filename, 'r', 'latin-1') as f:
 					data = f.read()
-					return self.match(data), None
+					return self.match(data, chars_before, chars_after), None
 			elif self.matchLocation == MatchLoc.FileContentAsBytes:
 				with open(filename, 'rb') as f:
 					data = f.read()
-					return self.match(data), None
+					return self.match(data, chars_before, chars_after), None
 			else:
 				return False, Exception('ERROR: Unknown match location: %s' % self.matchLocation)
 		except Exception as e:

--- a/pysnaffler/ruleset.py
+++ b/pysnaffler/ruleset.py
@@ -185,11 +185,11 @@ class SnafflerRuleSet:
 		self.unrollCache[lookupkey] = finalrules.values()
 		return finalrules.values()
 
-	async def parse_file(self, filepath, rules:List[SnaffleRule], fsize:int = 0):
+	async def parse_file(self, filepath, rules:List[SnaffleRule], fsize:int = 0, chars_before_match:int = 0, chars_after_match:int = 0):
 		finalrules = self.unroll_relays(rules)
 		for rule in finalrules:
 			if rule.enumerationScope == EnumerationScope.ContentsEnumeration:
-				res, err = rule.open_and_match(filepath)
+				res, err = rule.open_and_match(filepath, chars_before_match, chars_after_match)
 				if err is not None:
 					yield None, rule, err
 				if res:

--- a/pysnaffler/scanner.py
+++ b/pysnaffler/scanner.py
@@ -104,7 +104,7 @@ class SnafflerScanner:
 				# file got skipped
 				return
 			await out_queue.put(ScannerInfo(target, 'Processing %s' % smbfile.unc_path))
-			async for data, rule, err in self.snaffler.ruleset.parse_file(fpath, matchingrules, smbfile.size):
+			async for data, rule, err in self.snaffler.ruleset.parse_file(fpath, matchingrules, smbfile.size, self.snaffler.chars_before_match, self.snaffler.chars_after_match):
 				if err is not None:
 					# error handling ?
 					continue

--- a/pysnaffler/snaffler.py
+++ b/pysnaffler/snaffler.py
@@ -8,7 +8,8 @@ import os
 class pySnaffler:
 	def __init__(self, ruleset:SnafflerRuleSet = None, max_file_size:int = 10485760, max_connections:int = 200, 
 					max_downloads:int = 4, max_downloads_total:int = 20, keep_files:bool = False, 
-					download_base_dir:str = './snaffler_downloads', dry_run:bool = False, gen_filelist:bool = False):
+					download_base_dir:str = './snaffler_downloads', dry_run:bool = False, gen_filelist:bool = False,
+					chars_before_match:int = 0, chars_after_match:int = 0):
 		self.ruleset = ruleset
 		self.download_base_dir = download_base_dir
 		self.max_file_size = max_file_size
@@ -18,6 +19,8 @@ class pySnaffler:
 		self.keep_files = keep_files
 		self.dry_run = dry_run
 		self.gen_filelist = gen_filelist
+		self.chars_before_match = chars_before_match
+		self.chars_after_match = chars_after_match
 		self.stat_fcnt = 0
 		self.stat_fsize = 0
 		self.stat_flarge = 0
@@ -40,7 +43,9 @@ class pySnaffler:
 			'max_downloads_total' : self.max_downloads_total,
 			'keep_files' : self.keep_files,
 			'dry_run' : self.dry_run,
-			'gen_filelist' : self.gen_filelist
+			'gen_filelist' : self.gen_filelist,
+			'chars_before_match': self.chars_before_match,
+			'chars_after_match': self.chars_after_match
 		}
 
 	def to_toml(self):
@@ -70,7 +75,9 @@ class pySnaffler:
 			d['max_downloads_total'],
 			d['keep_files'],
 			d['dry_run'],
-			d['gen_filelist']
+			d['gen_filelist'],
+			d['chars_before_match'],
+			d['chars_after_match']
 		)
 
 	@staticmethod


### PR DESCRIPTION
Add two new parameters to specify how many characters before and after a match should be included in the output file.
This solves the issue that sometimes credentials are cut off in the output.