### PR TITLE
Add NFS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Snaffler's author's Twitter: @mikeloss and @sh3r4_hax
 The project is fully compatible with the TOML based rulesets from the original Snaffler project, the SMB connectivity is based on the [aiosmb](https://github.com/skelsec/aiosmb) library. Note: the Snaffler's core config file is NOT compatible with this project.
 
 # Usage
-Either install it via pip or just clone the project and install `toml` and `aiosmb>=0.4.5`.  
+Either install it via pip or just clone the project and install `toml`, `anfs` and `aiosmb>=0.4.5`.
 If installed via pip you'll get two executables: 
 - `pysnaffler`
 - `pysnaffler-whatif` (not tested)
@@ -32,4 +32,7 @@ Use `pysnaffler -h` to see all parameters.
   
 - Enumerate `win2019ad.test.corp` using the password credentials of `TEST\victim` user using `KERBEROS` auth.  
 `pysnaffler 'smb2+kerberos+password://TEST\victim:Passw0rd!1@win2019ad.test.corp/?dc=10.10.10.2' 10.10.10.2`
+
+- Enumerate `10.10.10.2` using NFS.
+`pysnaffler -n 'nfs://10.10.10.2/?privport=1' 10.10.10.2`
 

--- a/pysnaffler/protocol.py
+++ b/pysnaffler/protocol.py
@@ -1,0 +1,110 @@
+from abc import ABC, abstractmethod
+from typing import override
+
+from aiosmb.commons.interfaces.machine import SMBMachine
+from aiosmb.commons.interfaces.file import SMBFile
+
+from anfs.protocol.nfs3.client import NFSAccessError, NFSFileEntry
+
+class ProtocolClient(ABC):
+	@abstractmethod
+	def __init__(self, factory, target):
+		pass
+
+	@abstractmethod
+	async def connect_to_target(self, target):
+		pass
+
+	@abstractmethod
+	async def donwload_file(self, file, localpath, max_size):
+		pass
+
+	@abstractmethod
+	async def enum_files_with_filter(self, filter):
+		pass
+
+class SMBProtocolClient(ProtocolClient):
+	@override
+	def __init__(self, factory, target):
+		self.factory = factory
+		self.target = target
+		self.connection = None
+		self.machine = None
+
+	@override
+	async def connect_to_target(self, target):
+		self.connection = self.factory.create_connection_newtarget(target)
+		_, err = await self.connection.login()
+		if err is not None:
+			raise err
+
+		self.machine = SMBMachine(self.connection)
+
+	@override
+	async def donwload_file(self, file: SMBFile, localpath, max_size):
+		return await file.download(self.connection, localpath)
+
+	@override
+	async def enum_files_with_filter(self, filter):
+		async for obj, otype, err in self.machine.enum_files_with_filter(filter):
+			yield obj, otype, err
+
+class NFSProtocolClient(ProtocolClient):
+	@override
+	def __init__(self, factory, target):
+		self.factory = factory
+		self.target = target
+		self.connection = None
+		self.client = None
+		self.newfactory = None
+
+	@override
+	async def connect_to_target(self, target):
+		self.newfactory = self.factory.create_factory_newtarget(target)
+
+	@override
+	async def donwload_file(self, file, localpath, max_size):
+		return await self.client.download_file(file.nfs_file.handle, localpath, max_size = max_size, uid = file.nfs_file.uid, gid = file.nfs_file.gid)
+
+	@staticmethod
+	def filter_wrapper(filter, target, mount_path):
+		def filter_cb(entry_path, entry):
+			smb_obj = entry.to_smbfile(target, mount_path, entry_path)
+			return filter('dir', smb_obj)
+
+		return filter_cb
+
+	@override
+	async def enum_files_with_filter(self, filter):
+		async with self.newfactory.get_mount() as mount:
+			mountpoints, err = await mount.export()
+			if err is not None:
+				yield None, None, err
+				return
+
+			mounts = {}
+			for mountpoint in mountpoints:
+				mounts[mountpoint.filesys] = mountpoint
+
+			for mountpoint in mounts:
+				yield mounts[mountpoint].to_smbshare(self.target), 'share', None
+
+				mhandle, err = await mount.mount(mountpoint)
+				if err is not None:
+					continue
+
+				filter_cb = NFSProtocolClient.filter_wrapper(filter, self.target, mountpoint)
+
+				async with self.newfactory.get_client(mhandle) as nfs:
+					self.client = nfs
+					async for epath, etype, entry, err in nfs.enumall(0, depth=30, filter_cb = filter_cb):
+						if err is not None and not isinstance(err, NFSAccessError):
+							yield None, None, None, err
+						elif isinstance(entry, NFSFileEntry):
+							yield entry.to_smbfile(self.target, mountpoint, epath), etype, err
+
+	async def __aenter__(self):
+		return self
+	
+	async def __aexit__(self, exc_type, exc, tb):
+		await self.client.disconnect()

--- a/pysnaffler/snaffler.py
+++ b/pysnaffler/snaffler.py
@@ -9,7 +9,7 @@ class pySnaffler:
 	def __init__(self, ruleset:SnafflerRuleSet = None, max_file_size:int = 10485760, max_connections:int = 200, 
 					max_downloads:int = 4, max_downloads_total:int = 20, keep_files:bool = False, 
 					download_base_dir:str = './snaffler_downloads', dry_run:bool = False, gen_filelist:bool = False,
-					chars_before_match:int = 0, chars_after_match:int = 0):
+					chars_before_match:int = 0, chars_after_match:int = 0, nfs:bool = False):
 		self.ruleset = ruleset
 		self.download_base_dir = download_base_dir
 		self.max_file_size = max_file_size
@@ -21,6 +21,7 @@ class pySnaffler:
 		self.gen_filelist = gen_filelist
 		self.chars_before_match = chars_before_match
 		self.chars_after_match = chars_after_match
+		self.nfs = nfs
 		self.stat_fcnt = 0
 		self.stat_fsize = 0
 		self.stat_flarge = 0
@@ -45,7 +46,8 @@ class pySnaffler:
 			'dry_run' : self.dry_run,
 			'gen_filelist' : self.gen_filelist,
 			'chars_before_match': self.chars_before_match,
-			'chars_after_match': self.chars_after_match
+			'chars_after_match': self.chars_after_match,
+			'nfs': self.nfs
 		}
 
 	def to_toml(self):
@@ -77,7 +79,8 @@ class pySnaffler:
 			d['dry_run'],
 			d['gen_filelist'],
 			d['chars_before_match'],
-			d['chars_after_match']
+			d['chars_after_match'],
+			d['nfs']
 		)
 
 	@staticmethod

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
 	python_requires='>=3.7',
 	install_requires=[
 		'aiosmb>=0.4.7',
+		'anfs',
 		'toml',
 	],
 	


### PR DESCRIPTION
Add NFS support based on anfs.

This pull request requires https://github.com/skelsec/anfs/pull/7 to be merged in order to work.
In setup.py, I added a dependency to the latest release of anfs.
If you want to merge this, I think the easiest way to handle this would be to create a new release of anfs and then specify this as the minimum version in setup.py.